### PR TITLE
Fix comment for Google Colab

### DIFF
--- a/scripts_snapshot_collector.py
+++ b/scripts_snapshot_collector.py
@@ -1,4 +1,4 @@
-#For Google Collab
+# For Google Colab
 !pip install pytz
 !pip install duckdb pyarrow pandas
 


### PR DESCRIPTION
## Summary
- fix the opening comment in `scripts_snapshot_collector.py`
- ensure no incorrect "Collab" spelling remains

## Testing
- `python -m py_compile scripts_snapshot_collector.py` *(fails: SyntaxError due to Jupyter `!` commands)*

------
https://chatgpt.com/codex/tasks/task_e_685b73364f588329a9a7fe7657355d80